### PR TITLE
work around Windows Subsystem for Linux issue

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -1,19 +1,39 @@
 import * as net from 'net';
+import { weird } from './weird';
 
 export function check(port: number) {
-	return new Promise(fulfil => {
-		const server = net.createServer();
+	return weird().then(weird => {
+		if (weird) {
+			return check_weird(port);
+		}
 
-		server.unref();
+		return new Promise(fulfil => {
+			const server = net.createServer();
 
-		server.on('error', () => {
-			fulfil(false);
-		});
+			server.unref();
 
-		server.listen({ port }, () => {
-			server.close(() => {
-				fulfil(true);
+			server.on('error', () => {
+				fulfil(false);
+			});
+
+			server.listen({ port }, () => {
+				server.close(() => {
+					fulfil(true);
+				});
 			});
 		});
+	});
+}
+
+export function check_weird(port: number) {
+	return new Promise(fulfil => {
+		const client = net
+			.createConnection({ port }, () => {
+				client.end();
+				fulfil(false);
+			})
+			.on('error', () => {
+				fulfil(true);
+			});
 	});
 }

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,8 +1,16 @@
 import * as net from 'net';
+import { weird } from './weird';
 
 export function find(port: number): Promise<number> {
-	return new Promise((fulfil) => {
-		get_port(port, fulfil);
+	return <Promise<number>>weird().then(weird => {
+		if (weird) {
+			return new Promise(fulfil => {
+				get_port_weird(port, fulfil);
+			});
+		}
+		return new Promise(fulfil => {
+			get_port(port, fulfil);
+		});
 	});
 }
 
@@ -20,4 +28,15 @@ function get_port(port: number, cb: (port: number) => void) {
 			cb(port);
 		});
 	});
+}
+
+function get_port_weird(port: number, cb: (port: number) => void) {
+	const client = net
+		.createConnection({ port }, () => {
+			client.end();
+			get_port(port + 1, cb);
+		})
+		.on('error', () => {
+			cb(port);
+		});
 }

--- a/src/weird.ts
+++ b/src/weird.ts
@@ -1,0 +1,42 @@
+import * as net from 'net';
+
+let promise: Promise<any>;
+
+export function weird() {
+	if (!promise) {
+		promise = get_weird();
+	}
+	return promise;
+}
+
+function get_weird() {
+	return new Promise(fulfil => {
+		const server = net.createServer();
+
+		server.unref();
+
+		server.on('error', () => {
+			fulfil(false);
+		});
+
+		server.listen({ port: 9999 }, () => {
+			const server2 = net.createServer();
+
+			server2.unref();
+
+			server2.on('error', () => {
+				server.close(() => {
+					fulfil(false);
+				});
+			});
+
+			server2.listen({ port: 9999 }, () => {
+				server2.close(() => {
+					server.close(() => {
+						fulfil(true);
+					});
+				});
+			});
+		});
+	});
+}

--- a/src/weird.ts
+++ b/src/weird.ts
@@ -4,22 +4,22 @@ let promise: Promise<any>;
 
 export function weird() {
 	if (!promise) {
-		promise = get_weird();
+		promise = get_weird(9000);
 	}
 	return promise;
 }
 
-function get_weird() {
+function get_weird(port: number) {
 	return new Promise(fulfil => {
 		const server = net.createServer();
 
 		server.unref();
 
 		server.on('error', () => {
-			fulfil(false);
+			fulfil(get_weird(port + 1));
 		});
 
-		server.listen({ port: 9999 }, () => {
+		server.listen({ port }, () => {
 			const server2 = net.createServer();
 
 			server2.unref();
@@ -30,7 +30,7 @@ function get_weird() {
 				});
 			});
 
-			server2.listen({ port: 9999 }, () => {
+			server2.listen({ port }, () => {
 				server2.close(() => {
 					server.close(() => {
 						fulfil(true);


### PR DESCRIPTION
This isn't quiiiite an ideal solution. The idea is to attempt to open two servers on one port, and if that fails, assume that we're on WSL and switch future logic from using opening servers to using opening connections, which is slower.

The issue where WSL lets you open multiple servers on one port only seems to manifest if all of those servers were opened from within WSL. If one was already opened from within Windows itself, attempts to open one from within WSL fail with the expected EADDRINUSE. I'm guessing what's going on is that all of WSL is running as one Windows process and is taking care of the proxying to the virtual Linux processes itself - and so this is an understandable bug, but something I'd still consider a bug.

Anyway, what this means is that, with this PR, when we attempt to open two concurrent servers on one port, it might be that the first one was already opened in Windows, and that we still really are running in WSL - but in this case, we won't be able to determine that with this port. What I'm doing here is just assuming that means we're good to go (i.e., we're not on WSL) which isn't ideal. So either we need to check for WSL using a port that Definitely For Real Probably isn't in use by anything else that's likely to be running on the user's computer, or else we try with multiple different ports and keep going until we find one that we can open the first time (this is probably the best solution, it just would make this look uglier), or else we need to use a completely separate method for determining whether we're on WSL (which smells like an analogue of browser UA sniffing as opposed to feature detection, which isn't great).

Anyway, what there is here works better on WSL than what there was before (although not perfect). and it works marginally slower than before on non-WSL (because of the extra check at the beginning).