### PR TITLE
Adds a test for wait when node is under load on windows

### DIFF
--- a/src/wait.ts
+++ b/src/wait.ts
@@ -30,5 +30,5 @@ function get_connection(port: number, cb: () => void) {
 
 	timeout = setTimeout(() => {
 		socket.destroy();
-	}, 1000);
+	}, 5000);
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -98,12 +98,16 @@ describe('port-authority', () => {
 			assert.ok(listening);
 
 			// spin cpu so we have some load
-			spinCpu(5000);
 			// check we can still wait on port
-			await ports.wait(3000);
-
-			await server.close();
-		}).timeout(11000) // two * default ports.wait() timeouts + one second
+			try {
+				spinCpu(5000);
+				await ports.wait(3000);
+				await server.close();
+			}catch(error){
+				await server.close();
+				assert.fail(error.message);
+			}
+		}).timeout(11000); // two * default ports.wait() timeouts + one second
 	});
 });
 


### PR DESCRIPTION
This PR adds a test for `wait()` that fails due to timeout when the node process is under high cpu load in an attempt to simulate low performance conditions. Changing the timeout for calling `socket.destroy()` in `wait.ts` from `1000ms` to `3000ms` reduces the frequency of the timeout but it still occurs, `5000ms` and I'm unable to replicate the issue but I imagine it still exists.