### PR TITLE
Allow checking a specific host

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -1,10 +1,10 @@
 import * as net from 'net';
 import { weird } from './weird';
 
-export function check(port: number) {
+export function check(port: number, host?: string) {
 	return weird().then(weird => {
 		if (weird) {
-			return check_weird(port);
+			return check_weird(port, host);
 		}
 
 		return new Promise(fulfil => {
@@ -16,7 +16,7 @@ export function check(port: number) {
 				fulfil(false);
 			});
 
-			server.listen({ port }, () => {
+			server.listen({ port, host }, () => {
 				server.close(() => {
 					fulfil(true);
 				});
@@ -25,10 +25,10 @@ export function check(port: number) {
 	});
 }
 
-function check_weird(port: number) {
+function check_weird(port: number, host: string | undefined) {
 	return new Promise(fulfil => {
 		const client = net
-			.createConnection({ port }, () => {
+			.createConnection({ port, host }, () => {
 				client.end();
 				fulfil(false);
 			})

--- a/src/find.ts
+++ b/src/find.ts
@@ -23,7 +23,7 @@ function get_port(port: number, host: string | undefined, cb: (port: number) => 
 		get_port(port + 1, host, cb);
 	});
 
-	server.listen({ port }, () => {
+	server.listen({ port, host }, () => {
 		server.close(() => {
 			cb(port);
 		});

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,26 +1,26 @@
 import * as net from 'net';
 import { weird } from './weird';
 
-export function find(port: number): Promise<number> {
+export function find(port: number, host?: string): Promise<number> {
 	return <Promise<number>>weird().then(weird => {
 		if (weird) {
 			return new Promise(fulfil => {
-				get_port_weird(port, fulfil);
+				get_port_weird(port, host, fulfil);
 			});
 		}
 		return new Promise(fulfil => {
-			get_port(port, fulfil);
+			get_port(port, host, fulfil);
 		});
 	});
 }
 
-function get_port(port: number, cb: (port: number) => void) {
+function get_port(port: number, host: string | undefined, cb: (port: number) => void) {
 	const server = net.createServer();
 
 	server.unref();
 
 	server.on('error', () => {
-		get_port(port + 1, cb);
+		get_port(port + 1, host, cb);
 	});
 
 	server.listen({ port }, () => {
@@ -30,11 +30,11 @@ function get_port(port: number, cb: (port: number) => void) {
 	});
 }
 
-function get_port_weird(port: number, cb: (port: number) => void) {
+function get_port_weird(port: number, host: string | undefined, cb: (port: number) => void) {
 	const client = net
 		.createConnection({ port }, () => {
 			client.end();
-			get_port(port + 1, cb);
+			get_port(port + 1, host, cb);
 		})
 		.on('error', () => {
 			cb(port);

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -1,22 +1,22 @@
 import * as net from 'net';
 
-export function wait(port: number, { timeout = 5000 } = {}) {
+export function wait(port: number, { timeout = 5000, host = 'localhost' } = {}) {
 	return new Promise((fulfil, reject) => {
 		const t = setTimeout(() => {
 			reject(new Error(`timed out waiting for connection`))
 		}, timeout);
 
-		get_connection(port, () => {
+		get_connection(port, host, () => {
 			clearTimeout(t);
 			fulfil();
 		});
 	});
 }
 
-function get_connection(port: number, cb: () => void) {
+function get_connection(port: number, host: string, cb: () => void) {
 	let timeout: NodeJS.Timer;
 
-	const socket = net.connect(port, 'localhost', () => {
+	const socket = net.connect(port, host, () => {
 		cb();
 		socket.destroy();
 		clearTimeout(timeout);
@@ -25,7 +25,7 @@ function get_connection(port: number, cb: () => void) {
 	socket.on('error', () => {
 		clearTimeout(timeout);
 		setTimeout(() => {
-			get_connection(port, cb);
+			get_connection(port, host, cb);
 		}, 10);
 	});
 


### PR DESCRIPTION
By default, node's server listens on the unspecified IPv6 or IPv4 address. If an application has acquired a port by binding to another address (e.g. only `127.0.0.1`), that default behavior won't detect the port as in use.

This allows specifying a host to check, find, or wait for a port on if the unspecified address is not sufficient.

Fixes #8